### PR TITLE
Fix typo in README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ MarinePowerDynamics.jl introduces the **LinearPTO node**, supporting dynamic cou
 ---
 ### Installation Issues
 
-If you're attemping to add this package to an existing Julia environment and encounter issues, try the following:
+If you're attempting to add this package to an existing Julia environment and encounter issues, try the following:
 
 ```julia
 


### PR DESCRIPTION
## Summary
- fix "attempting" typo in Installation Issues section

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: julia command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b714dce48321b976047f0f91860e