### PR TITLE
Fix node bounds checks in PowerGridSolution

### DIFF
--- a/src/common/PowerGridSolutions.jl
+++ b/src/common/PowerGridSolutions.jl
@@ -56,7 +56,7 @@ end
 
 (sol::PowerGridSolution)(t, ::Colon, sym::Symbol, args...; kwargs...) = sol(t, collect(keys(sol.powergrid.nodes)), sym, args...; kwargs...)
 (sol::PowerGridSolution)(t, n, sym::Symbol, args...) = begin
-    if ~all( 1 .<= n .<= length(sol.powergrid.nodes) )
+    if any(n .< 1) || any(n .> length(sol.powergrid.nodes))
         throw(StateError("Index: $n is outside of range of nodes."))
     else
         sol(t, n, Val{sym}, args...)
@@ -76,7 +76,7 @@ end
 (sol::PowerGridSolution)(t, n::Array, sym::Symbol, args...) = begin
     bus_array=collect(keys(sol.powergrid.nodes))
     ni=[findfirst(x->x==nx, bus_array) for nx in n]
-    if any(ni.===nothing)||(~all( 1 .<= ni .<= length(sol.powergrid.nodes) ))
+    if any(ni .=== nothing) || any(ni .< 1) || any(ni .> length(sol.powergrid.nodes))
         throw(StateError("Array: $n is not in bus dictionary."))
     else
         sol(t, n, Val{sym}, args...)


### PR DESCRIPTION
## Summary
- replace chained comparison with explicit lower/upper bound checks for node indices
- fix array node index validation to avoid invalid comparisons

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*
- `apt-get install -y julia >/tmp/install.log && tail -n 20 /tmp/install.log` *(fails: Unable to locate package julia)*
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b72cb4f48321bc7d4589e279a2f7