### PR TITLE
Add PowerGridSolution indexing bound test

### DIFF
--- a/test/power_grid_solution_indexing.jl
+++ b/test/power_grid_solution_indexing.jl
@@ -1,0 +1,17 @@
+using Test
+using MarinePowerDynamics
+using Graphs
+import DiffEqBase: AbstractTimeseriesSolution
+import SciMLBase
+
+struct DummySolution <: AbstractTimeseriesSolution
+    retcode::SciMLBase.ReturnCode
+end
+
+@testset "PowerGridSolution indexing" begin
+    pg = PowerGrid(SimpleGraph(1), [1], [])
+    dummy = DummySolution(SciMLBase.ReturnCode.Success)
+    sol = PowerGridSolution(dummy, pg)
+    @test_throws StateError sol(0.0, 2, :v)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,2 @@
+using Test
+include("power_grid_solution_indexing.jl")


### PR DESCRIPTION
## Summary
- add regression test for PowerGridSolution indexing out-of-range

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a6b74328b88321b6e72ecd070c5b9d